### PR TITLE
Fixed unidentified key in lowMach_test.par

### DIFF
--- a/lowMach_test/lowMach_test.par
+++ b/lowMach_test/lowMach_test.par
@@ -5,7 +5,7 @@
 startFrom = #restart.fld 
 stopAt = nSteps #endTime
 endTime = 1.0
-nSteps = 5000
+numSteps = 5000
 
 dt = 1e-03
 timeStepper = bdf #char #steady


### PR DESCRIPTION
The "nSteps" key should be named "numSteps".  